### PR TITLE
Replace packr2 with go.rice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@ debug*
 tmpout
 tmpcache
 screenshottemp
-main-packr.go
-a_main-packr.go
-packrd
+rice-box.go
 mediaweb
 mediaweb.exe
 mediaweb.log

--- a/main_common.go
+++ b/main_common.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	packr "github.com/gobuffalo/packr/v2"
+	"github.com/GeertJohan/go.rice"
 	"github.com/midstar/llog"
 )
 
@@ -15,7 +15,7 @@ func mainCommon() *WebAPI {
 	llog.Info("Version: %s", applicationVersion)
 	llog.Info("Build time: %s", applicationBuildTime)
 	llog.Info("Git hash: %s", applicationGitHash)
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, s.mediaPath, s.thumbPath,
 		s.enableThumbCache, s.genThumbsOnStartup, s.autoRotate)
 	webAPI := CreateWebAPI(s.port, "templates", media, box, s.userName, s.password)

--- a/media.go
+++ b/media.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GeertJohan/go.rice"
 	"github.com/disintegration/imaging"
-	packr "github.com/gobuffalo/packr/v2"
 	"github.com/midstar/llog"
 	"github.com/rwcarlsen/goexif/exif"
 )
@@ -23,12 +23,12 @@ var vidExtensions = [...]string{".avi", ".mov", ".vid", ".mkv", ".mp4"}
 
 // Media represents the media including its base path
 type Media struct {
-	mediaPath          string     // Top level path for media files
-	thumbPath          string     // Top level path for thumbnails
-	enableThumbCache   bool       // Generate thumbnails
-	autoRotate         bool       // Rotate JPEG files when needed
-	box                *packr.Box // For icons
-	thumbGenInProgress bool       // True if thumbnail generation in progress
+	mediaPath          string    // Top level path for media files
+	thumbPath          string    // Top level path for thumbnails
+	enableThumbCache   bool      // Generate thumbnails
+	autoRotate         bool      // Rotate JPEG files when needed
+	box                *rice.Box // For icons
+	thumbGenInProgress bool      // True if thumbnail generation in progress
 }
 
 // File represents a folder or any other file
@@ -40,7 +40,7 @@ type File struct {
 
 // createMedia creates a new media. If thumb cache is enabled the path is
 // created when needed.
-func createMedia(box *packr.Box, mediaPath string, thumbPath string, enableThumbCache, genThumbsOnStartup, autoRotate bool) *Media {
+func createMedia(box *rice.Box, mediaPath string, thumbPath string, enableThumbCache, genThumbsOnStartup, autoRotate bool) *Media {
 	llog.Info("Media path: %s", mediaPath)
 	if enableThumbCache {
 		directory := filepath.Dir(thumbPath)
@@ -482,7 +482,7 @@ func (m *Media) getVideoIcon() (image.Image, error) {
 		return videoIcon, nil
 	}
 	var err error
-	videoIconBytes, _ := m.box.Find("icon_video.png")
+	videoIconBytes, _ := m.box.Bytes("icon_video.png")
 	videoIcon, err = imaging.Decode(bytes.NewReader(videoIconBytes))
 	if err != nil {
 		return nil, err

--- a/media_test.go
+++ b/media_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	packr "github.com/gobuffalo/packr/v2"
+	rice "github.com/GeertJohan/go.rice"
 )
 
 type timerType struct {
@@ -30,7 +30,7 @@ func LogTime(t *testing.T, whatWasMeasured string) {
 }
 
 func TestGetFiles(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", ".", true, false, true)
 	files, err := media.getFiles("")
 	assertExpectNoErr(t, "", err)
@@ -38,7 +38,7 @@ func TestGetFiles(t *testing.T) {
 }
 
 func TestGetFilesInvalid(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", ".", true, false, true)
 	files, err := media.getFiles("invalidfolder")
 	assertExpectErr(t, "invalid path shall give errors", err)
@@ -46,7 +46,7 @@ func TestGetFilesInvalid(t *testing.T) {
 }
 
 func TestGetFilesHacker(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", ".", true, false, true)
 	files, err := media.getFiles("../..")
 	assertExpectErr(t, "hacker path shall give errors", err)
@@ -54,7 +54,7 @@ func TestGetFilesHacker(t *testing.T) {
 }
 
 func TestIsRotationNeeded(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", ".", true, false, true)
 
 	rotationNeeded := media.isRotationNeeded("exif_rotate/180deg.jpg")
@@ -104,7 +104,7 @@ func TestRotateAndWrite(t *testing.T) {
 	outFileName := "tmpout/TestRotateAndWrite/jpeg_rotated_fixed.jpg"
 	os.MkdirAll("tmpout/TestRotateAndWrite", os.ModePerm) // If already exist no problem
 	os.Remove(outFileName)
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", ".", true, false, true)
 	outFile, err := os.Create(outFileName)
 	assertExpectNoErr(t, "unable to create out", err)
@@ -134,7 +134,7 @@ func tEXIFThumbnail(t *testing.T, media *Media, filename string) {
 
 func TestWriteEXIFThumbnail(t *testing.T) {
 	os.MkdirAll("tmpout/TestWriteEXIFThumbnail", os.ModePerm) // If already exist no problem
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", ".", true, false, true)
 
 	tEXIFThumbnail(t, media, "normal.jpg")
@@ -159,7 +159,7 @@ func TestWriteEXIFThumbnail(t *testing.T) {
 
 func TestFullPath(t *testing.T) {
 	// Root path
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, ".", ".", true, false, true)
 	p, err := media.getFullMediaPath("afile.jpg")
 	assertExpectNoErr(t, "unable to get valid full path", err)
@@ -188,7 +188,7 @@ func TestFullPath(t *testing.T) {
 }
 
 func TestThumbnailPath(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "/c/mediapath", "/d/thumbpath", true, false, true)
 
 	thumbPath, err := media.thumbnailPath("myimage.jpg")
@@ -224,7 +224,7 @@ func tGenerateImageThumbnail(t *testing.T, media *Media, inFileName, outFileName
 func TestGenerateImageThumbnail(t *testing.T) {
 	os.MkdirAll("tmpout/TestGenerateImageThumbnail", os.ModePerm) // If already exist no problem
 
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "", "", true, false, true)
 
 	tGenerateImageThumbnail(t, media, "testmedia/jpeg.jpg", "tmpout/TestGenerateImageThumbnail/jpeg_thumbnail.jpg")
@@ -263,7 +263,7 @@ func TestWriteThumbnail(t *testing.T) {
 	os.RemoveAll("tmpout/TestWriteThumbnail")
 	os.MkdirAll("tmpout/TestWriteThumbnail", os.ModePerm)
 
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", "tmpcache/TestWriteThumbnail", true, false, true)
 
 	// JPEG with embedded EXIF
@@ -304,7 +304,7 @@ func TestVideoThumbnailSupport(t *testing.T) {
 		ffmpegCmd = origCmd
 	}()
 
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "", "", true, false, true)
 
 	t.Logf("ffmpeg supported: %v", media.videoThumbnailSupport())
@@ -333,7 +333,7 @@ func tGenerateVideoThumbnail(t *testing.T, media *Media, inFileName, outFileName
 }
 
 func TestGenerateVideoThumbnail(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "", "", true, false, true)
 	if !media.videoThumbnailSupport() {
 		t.Skip("ffmpeg not installed skipping test")
@@ -359,7 +359,7 @@ func TestGenerateThumbnails(t *testing.T) {
 	os.RemoveAll(cache)
 	os.MkdirAll(cache, os.ModePerm)
 
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", cache, true, false, true)
 	stat := media.generateThumbnails("")
 	assertEqualsInt(t, "", 1, stat.NbrOfFolders)
@@ -394,7 +394,7 @@ func TestGenerateAllThumbnails(t *testing.T) {
 	os.RemoveAll(cache)
 	os.MkdirAll(cache, os.ModePerm)
 
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", cache, true, true, true)
 
 	for i := 0; i < 300; i++ {
@@ -427,7 +427,7 @@ func TestGenerateNoThumbnails(t *testing.T) {
 	os.RemoveAll(cache)
 	os.MkdirAll(cache, os.ModePerm)
 
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", cache, true, false, true)
 
 	assertFalse(t, "", media.thumbGenInProgress)

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -11,16 +11,9 @@ for /f %%i in ('git rev-parse HEAD') do set GITHASH=%%i
 echo git hash: %GITHASH%
 echo building / installing
 cd %GOPATH%\src\github.com\midstar\mediaweb
-set PACKRCMD=packr2 
-echo %PACKRCMD%
-%PACKRCMD%
-REM There is a bug in packr that creates absolute paths in main-packr.go on some
-REM build machines (uncertain why). Replace main-packr.go with a new file
-echo Replacing main-packr.go due to a bug in packr library
-echo // +build !skippackr > main-packr.go
-echo. > main-packr.go
-echo package main >> main-packr.go
-echo import _ "github.com/midstar/mediaweb/packrd" >> main-packr.go
+set RICECMD=rice embed-go
+echo %RICECMD%
+%RICECMD%
 set INSTALLCMD=go build -ldflags="-X 'main.applicationBuildTime=%DATE% %TIME%' -X main.applicationVersion=%VERSION% -X main.applicationGitHash=%GITHASH%" github.com/midstar/mediaweb
 echo %INSTALLCMD%
 %INSTALLCMD%

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,6 +15,6 @@ echo date time: $DATETIME
 
 echo building / installing
 cd $GOPATH/src/github.com/midstar/mediaweb
-packr2
+rice embed-go
 go build -ldflags="-X 'main.applicationBuildTime=$DATETIME' -X main.applicationVersion=$1 -X main.applicationGitHash=$GITHASH" github.com/midstar/mediaweb
 

--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -2,6 +2,6 @@ go get github.com/midstar/llog
 go get github.com/midstar/gocfg
 go get github.com/disintegration/imaging
 go get github.com/rwcarlsen/goexif/exif
-go get -u github.com/gobuffalo/packr/v2/...
-go get -u github.com/gobuffalo/packr/v2/packr2
+go get github.com/GeertJohan/go.rice
+go get github.com/GeertJohan/go.rice/rice
 go get github.com/kardianos/service

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -2,5 +2,5 @@ go get github.com/midstar/llog
 go get github.com/midstar/gocfg
 go get github.com/disintegration/imaging
 go get github.com/rwcarlsen/goexif/exif
-go get -u github.com/gobuffalo/packr/v2/...
-go get -u github.com/gobuffalo/packr/v2/packr2
+go get github.com/GeertJohan/go.rice
+go get github.com/GeertJohan/go.rice/rice

--- a/webapi.go
+++ b/webapi.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	packr "github.com/gobuffalo/packr/v2"
+	"github.com/GeertJohan/go.rice"
 	"github.com/midstar/llog"
 )
 
@@ -18,13 +18,13 @@ type WebAPI struct {
 	server       *http.Server
 	templatePath string // Path to the templates
 	media        *Media
-	box          *packr.Box
+	box          *rice.Box
 	userName     string // User name ("" means no authentication)
 	password     string // Password
 }
 
 // CreateWebAPI creates a new Web API instance
-func CreateWebAPI(port int, templatePath string, media *Media, box *packr.Box, userName, password string) *WebAPI {
+func CreateWebAPI(port int, templatePath string, media *Media, box *rice.Box, userName, password string) *WebAPI {
 	portStr := fmt.Sprintf(":%d", port)
 	server := &http.Server{Addr: portStr}
 	webAPI := &WebAPI{
@@ -105,7 +105,7 @@ func (wa *WebAPI) serveHTTPStatic(w http.ResponseWriter, r *http.Request) {
 		// Default is index page
 		fileName = "index.html"
 	}
-	bytes, err := wa.box.Find(fileName)
+	bytes, err := wa.box.Bytes(fileName)
 	if err != nil || len(bytes) == 0 {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprintf(w, "Unable to find: %s!", fileName)
@@ -168,20 +168,20 @@ func (wa *WebAPI) serveHTTPThumbnail(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		w.Header().Set("Content-Type", "image/jpeg")
 	} else {
-		// No thumbnail. Use the default 
+		// No thumbnail. Use the default
 		w.Header().Set("Content-Type", "image/png")
 		fileType := wa.media.getFileType(relativePath)
 		if fileType == "image" {
-			iconImage, _ := wa.box.Find("icon_image.png")
+			iconImage, _ := wa.box.Bytes("icon_image.png")
 			w.Write(iconImage)
 			//http.ServeFile(w, r, wa.templatePath+"/icon_image.png")
 		} else if fileType == "video" {
-			iconVideo, _ := wa.box.Find("icon_video.png")
+			iconVideo, _ := wa.box.Bytes("icon_video.png")
 			w.Write(iconVideo)
 			//http.ServeFile(w, r, wa.templatePath+"/icon_video.png")
 		} else {
 			// Folder
-			iconFolder, _ := wa.box.Find("icon_folder.png")
+			iconFolder, _ := wa.box.Bytes("icon_folder.png")
 			w.Write(iconFolder)
 			//http.ServeFile(w, r, wa.templatePath+"/icon_folder.png")
 		}

--- a/webapi_test.go
+++ b/webapi_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	packr "github.com/gobuffalo/packr/v2"
+	rice "github.com/GeertJohan/go.rice"
 )
 
 var baseURL = "http://localhost:9834"
@@ -216,7 +216,7 @@ func TestGetThumbnail(t *testing.T) {
 }
 
 func TestGetThumbnailNoCache(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", "", false, false, true)
 	webAPI := CreateWebAPI(9834, "templates", media, box, "", "")
 	webAPI.Start()
@@ -257,7 +257,7 @@ func TestInvalidPath(t *testing.T) {
 }
 
 func TestAuthentication(t *testing.T) {
-	box := packr.New("templates", "./templates")
+	box := rice.MustFindBox("templates")
 	media := createMedia(box, "testmedia", "", true, false, true)
 	webAPI := CreateWebAPI(9834, "templates", media, box, "myuser", "mypass")
 	webAPI.Start()


### PR DESCRIPTION
Replaced packr2 with go.rice since packr2 has bugs that will fail Windows builds on Appveyor.